### PR TITLE
Merge and remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,16 @@ fixturify.writeSync('testdir', obj) // write it to disk
 
 fixturify.readSync('testdir') // => deep-equals obj
 
-fs.removeSync('testDir', {
-    'subdir': { 'bar.txt' }
-  }) // remove subdir/bar.txt
+fs.writeSync('testDir', {
+  'subdir': { 'bar.txt': null }
+}) // remove subdir/bar.txt
 
 fixturify.readSync('testdir') // => { foo.txt: 'foo.text contents' }
+
+fs.writeSync('testDir', {
+  'subdir': null
+}) // remove subdir/
+
 ```
 
 File contents are decoded and encoded with UTF-8.
@@ -54,6 +59,3 @@ To keep the API simple, node-fixturify has the following limitations:
 
 * File contents are automatically encoded/decoded into strings. Binary files
   are not supported.
-
-* Removing files resulting in a newly empty directory, will also remove that directory
-

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ var obj = {
 fixturify.writeSync('testdir', obj) // write it to disk
 
 fixturify.readSync('testdir') // => deep-equals obj
+
+fs.removeSync('testDir', {
+    'subdir': { 'bar.txt' }
+  }) // remove subdir/bar.txt
+
+fixturify.readSync('testdir') // => { foo.txt: 'foo.text contents' }
 ```
 
 File contents are decoded and encoded with UTF-8.
@@ -48,3 +54,6 @@ To keep the API simple, node-fixturify has the following limitations:
 
 * File contents are automatically encoded/decoded into strings. Binary files
   are not supported.
+
+* Removing files resulting in a newly empty directory, will also remove that directory
+

--- a/index.js
+++ b/index.js
@@ -21,6 +21,14 @@ function readSync (dir) {
 
 exports.writeSync = writeSync
 function writeSync (dir, obj) {
+  if ('string' !== typeof dir) {
+    throw new TypeError('writeSync first argument must be a string')
+  }
+
+  if ('object' !== typeof obj && obj !== null) {
+    throw new TypeError('writeSync second argument must be an object')
+  }
+
   for (var entry in obj) {
     if (obj.hasOwnProperty(entry)) {
       var fullPath = dir + '/' + entry
@@ -35,6 +43,7 @@ function writeSync (dir, obj) {
         if (stat && stat.isDirectory()) {
           fs.removeSync(fullPath)
         }
+
         fs.writeFileSync(fullPath, value, 'UTF8')
       } else if (typeof value === 'object') {
         if (value === null) {

--- a/index.js
+++ b/index.js
@@ -28,7 +28,15 @@ function writeSync (dir, obj) {
       if (typeof value === 'string') {
         fs.writeFileSync(fullPath, value, { encoding: 'utf8' })
       } else if (typeof value === 'object') {
-        fs.mkdirSync(fullPath)
+        try {
+          fs.mkdirSync(fullPath)
+        } catch (e) {
+          // if the directory already exists, carry on.
+          // This is to support, re-appling (append-only) of fixtures
+          if (!(typeof e === 'object' && e !== null && e.code === 'EEXIST')) {
+            throw e
+          }
+        }
         writeSync(fullPath, value)
       } else {
         throw new Error(entry + ' in ' + dir + ': Expected string or object, got ' + value)

--- a/index.js
+++ b/index.js
@@ -44,3 +44,36 @@ function writeSync (dir, obj) {
     }
   }
 }
+
+exports.removeSync = removeSync
+function removeSync (dir, obj) {
+  var removes = [];
+  var fullPath;
+
+  for (var entry in obj) {
+    if (obj.hasOwnProperty(entry)) {
+      var value = obj[entry];
+      fullPath = dir + '/' + entry
+
+      if (typeof value === 'string') {
+        removes.push(fullPath);
+      } else if (typeof value === 'object') {
+        removes.push(fullPath);
+        removeSync(fullPath, value)
+      } else {
+        throw new Error(entry + ' in ' + dir + ': Expected string or object, got ' + value)
+      }
+    }
+  }
+
+  for (var i = 0; i < removes.length; i++) {
+    fullPath = removes[i];
+    var stats = fs.statSync(fullPath) // stat, unlike lstat, follows symlinks
+
+    if (stats.isFile()) {
+      fs.unlinkSync(fullPath);
+    } else if (stats.isDirectory() && fs.readdirSync(fullPath).length === 0) {
+      fs.rmdirSync(fullPath);
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "type": "git",
     "url": "https://github.com/joliss/node-fixturify"
   },
-  "dependencies": {},
+  "dependencies": {
+    "fs-extra": "^0.30.0"
+  },
   "devDependencies": {
     "rimraf": "^2.2.6",
     "tap": "^0.4.8",

--- a/test.js
+++ b/test.js
@@ -10,15 +10,30 @@ test('writeSync', function (t) {
   fs.mkdirSync('testdir.tmp')
   fixturify.writeSync('testdir.tmp', {
     'foo.txt': 'foo.txt contents',
-      'subdir': {
-        'bar.txt': 'bar.txt contents'
-      }
-    })
+    'subdir': {
+      'bar.txt': 'bar.txt contents'
+    }
+  })
 
   t.deepEqual(fs.readdirSync('testdir.tmp').sort(), ['foo.txt', 'subdir'])
   t.deepEqual(fs.readdirSync('testdir.tmp/subdir').sort(), ['bar.txt'])
-  t.equal(fs.readFileSync('testdir.tmp/foo.txt', { encoding: 'utf8' }), 'foo.txt contents')
-  t.equal(fs.readFileSync('testdir.tmp/subdir/bar.txt', { encoding: 'utf8' }), 'bar.txt contents')
+  t.equal(fs.readFileSync('testdir.tmp/foo.txt', 'UTF8'), 'foo.txt contents')
+  t.equal(fs.readFileSync('testdir.tmp/subdir/bar.txt', 'UTF8'), 'bar.txt contents')
+
+  fixturify.writeSync('testdir.tmp', {
+    'something': 'foo.txt contents',
+    'else': {
+      'bar.txt': 'bar.txt contents'
+    }
+  })
+
+  t.deepEqual(fs.readdirSync('testdir.tmp').sort(), ['else', 'foo.txt', 'something', 'subdir'])
+  t.deepEqual(fs.readdirSync('testdir.tmp/subdir').sort(), ['bar.txt'])
+  t.deepEqual(fs.readdirSync('testdir.tmp/else').sort(), ['bar.txt'])
+
+  t.equal(fs.readFileSync('testdir.tmp/foo.txt', 'UTF8'), 'foo.txt contents')
+  t.equal(fs.readFileSync('testdir.tmp/subdir/bar.txt', 'UTF8'), 'bar.txt contents')
+  t.equal(fs.readFileSync('testdir.tmp/else/bar.txt',  'UTF8'), 'bar.txt contents')
 
   rimraf.sync('testdir.tmp')
   t.end()

--- a/test.js
+++ b/test.js
@@ -34,13 +34,13 @@ test('writeSync', function (t) {
   t.equal(fs.readFileSync('testdir.tmp/subdir/bar.txt', 'UTF8'), 'bar.txt contents')
   t.equal(fs.readFileSync('testdir.tmp/else/bar.txt',  'UTF8'), 'bar.txt contents')
 
-  fixturify.writeSync('testDir.tmp', {
+  fixturify.writeSync('testdir.tmp', {
     'else': 'else is now a file'
   })
 
   t.equal(fs.readFileSync('testdir.tmp/else',  'UTF8'), 'else is now a file')
 
-  fixturify.writeSync('testDir.tmp', {
+  fixturify.writeSync('testdir.tmp', {
     'empty-dir': { }
   })
   t.deepEqual(fs.readdirSync('testdir.tmp/empty-dir').sort(), [])
@@ -123,6 +123,22 @@ test('error conditions', function (t) { test('writeSync requires directory to ex
   test('readSync requires directory to exist', function (t) {
     t.throws(function () {
       fixturify.readSync('doesnotexist')
+    })
+    t.end()
+  })
+
+  test('writeSync arguments requires specific input', function (t) {
+    t.throws(function () {
+      fixturify.writeSync()
+    })
+    t.throws(function () {
+      fixturify.writeSync(null)
+    })
+    t.throws(function () {
+      fixturify.writeSync(null, null)
+    })
+    t.throws(function () {
+      fixturify.writeSync(null, {})
     })
     t.end()
   })

--- a/test.js
+++ b/test.js
@@ -4,7 +4,6 @@ var rimraf = require('rimraf')
 
 var fixturify = require('./')
 
-
 test('writeSync', function (t) {
   rimraf.sync('testdir.tmp')
   fs.mkdirSync('testdir.tmp')
@@ -49,18 +48,55 @@ test('readSync', function (t) {
 
   t.deepEqual(fixturify.readSync('testdir.tmp'), {
     'foo.txt': 'foo.txt contents',
-      'subdir': {
-        'bar.txt': 'bar.txt contents',
-        'symlink': 'foo.txt contents'
-      }
-    })
+    'subdir': {
+      'bar.txt': 'bar.txt contents',
+      'symlink': 'foo.txt contents'
+    }
+  })
 
   rimraf.sync('testdir.tmp')
   t.end()
 })
 
-test('error conditions', function (t) {
-  test('writeSync requires directory to exist, if given non-empty object', function (t) {
+test('removeSync', function (t) {
+  rimraf.sync('testdir.tmp')
+  fs.mkdirSync('testdir.tmp')
+  fs.writeFileSync('testdir.tmp/foo.txt', 'foo.txt contents')
+  fs.mkdirSync('testdir.tmp/subdir')
+  fs.writeFileSync('testdir.tmp/subdir/bar.txt', 'bar.txt contents')
+  fs.symlinkSync('../foo.txt', 'testdir.tmp/subdir/symlink')
+
+  fixturify.removeSync('testdir.tmp', {
+    'subdir': {
+      'symlink': 'foo.txt contents'
+    }
+  })
+
+  t.deepEqual(fs.readdirSync('testdir.tmp').sort(), ['foo.txt', 'subdir'])
+  t.deepEqual(fs.readdirSync('testdir.tmp/subdir').sort(), ['bar.txt'])
+  t.equal(fs.readFileSync('testdir.tmp/foo.txt', 'UTF8'), 'foo.txt contents')
+  t.equal(fs.readFileSync('testdir.tmp/subdir/bar.txt', 'UTF8'), 'bar.txt contents')
+
+  // no way to easily disambiguate between empty directory and removing it \w
+  // removeSync. Instead of leaking empty diretories, or forcing multiple
+  // removeSync, if a directory becomes empty due to removeSync we also remove this.
+  //
+  // We could change this, so that empty directories remain, but require
+  // multiple removeSync to purge.  Although this approach, appears to be a
+  // reasonable balance
+  fixturify.removeSync('testdir.tmp', {
+    'subdir': {
+      'bar.txt': ''
+    }
+  })
+
+  t.deepEqual(fs.readdirSync('testdir.tmp/').sort(), ['foo.txt'])
+
+  rimraf.sync('testdir.tmp')
+  t.end()
+})
+
+test('error conditions', function (t) { test('writeSync requires directory to exist, if given non-empty object', function (t) {
     t.throws(function () {
       fixturify.writeSync('doesnotexist', { 'foo.txt': 'contents' })
     })

--- a/test.js
+++ b/test.js
@@ -34,6 +34,16 @@ test('writeSync', function (t) {
   t.equal(fs.readFileSync('testdir.tmp/subdir/bar.txt', 'UTF8'), 'bar.txt contents')
   t.equal(fs.readFileSync('testdir.tmp/else/bar.txt',  'UTF8'), 'bar.txt contents')
 
+  fixturify.writeSync('testDir.tmp', {
+    'else': 'else is now a file'
+  })
+
+  t.equal(fs.readFileSync('testdir.tmp/else',  'UTF8'), 'else is now a file')
+
+  fixturify.writeSync('testDir.tmp', {
+    'empty-dir': { }
+  })
+  t.deepEqual(fs.readdirSync('testdir.tmp/empty-dir').sort(), [])
   rimraf.sync('testdir.tmp')
   t.end()
 })
@@ -58,7 +68,7 @@ test('readSync', function (t) {
   t.end()
 })
 
-test('removeSync', function (t) {
+test('writeSync remove', function (t) {
   rimraf.sync('testdir.tmp')
   fs.mkdirSync('testdir.tmp')
   fs.writeFileSync('testdir.tmp/foo.txt', 'foo.txt contents')
@@ -66,9 +76,9 @@ test('removeSync', function (t) {
   fs.writeFileSync('testdir.tmp/subdir/bar.txt', 'bar.txt contents')
   fs.symlinkSync('../foo.txt', 'testdir.tmp/subdir/symlink')
 
-  fixturify.removeSync('testdir.tmp', {
+  fixturify.writeSync('testdir.tmp', {
     'subdir': {
-      'symlink': 'foo.txt contents'
+      'symlink': null
     }
   })
 
@@ -77,19 +87,26 @@ test('removeSync', function (t) {
   t.equal(fs.readFileSync('testdir.tmp/foo.txt', 'UTF8'), 'foo.txt contents')
   t.equal(fs.readFileSync('testdir.tmp/subdir/bar.txt', 'UTF8'), 'bar.txt contents')
 
-  // no way to easily disambiguate between empty directory and removing it \w
-  // removeSync. Instead of leaking empty diretories, or forcing multiple
-  // removeSync, if a directory becomes empty due to removeSync we also remove this.
-  //
-  // We could change this, so that empty directories remain, but require
-  // multiple removeSync to purge.  Although this approach, appears to be a
-  // reasonable balance
-  fixturify.removeSync('testdir.tmp', {
+  fixturify.writeSync('testdir.tmp', {
     'subdir': {
-      'bar.txt': ''
+      'bar.txt': null
     }
   })
 
+  t.deepEqual(fs.readdirSync('testdir.tmp/').sort(), ['foo.txt', 'subdir'])
+
+  fixturify.writeSync('testdir.tmp', {
+    'subdir': {
+      'bar.txt': 'hi'
+    }
+  })
+
+  t.deepEqual(fs.readdirSync('testdir.tmp/').sort(), ['foo.txt', 'subdir'])
+  t.equal(fs.readFileSync('testdir.tmp/subdir/bar.txt', 'UTF8'), 'hi')
+
+  fixturify.writeSync('testdir.tmp', {
+    'subdir': null
+  })
   t.deepEqual(fs.readdirSync('testdir.tmp/').sort(), ['foo.txt'])
 
   rimraf.sync('testdir.tmp')


### PR DESCRIPTION
When testing broccoli-plugins, an important category of tests are rebuilds which contain removes and updates. This PR enables:
1. updating existing fixture outputs, by enabling `writeSync` to apply patches to an existing directory tree.
2. removing existing fixture entry, via `removeSync`.
