### PR TITLE
no longer require extra boilerplate of mkdirSync before using `fs.wri…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ npm install --save-dev fixturify
 var fs = require('fs')
 var fixturify = require('fixturify')
 
-fs.mkdirSync('testdir')
-
 var obj = {
   'foo.txt': 'foo.txt contents',
   'subdir': {

--- a/index.js
+++ b/index.js
@@ -21,6 +21,8 @@ function readSync (dir) {
 
 exports.writeSync = writeSync
 function writeSync (dir, obj) {
+  fs.mkdirpSync(dir);
+
   if ('string' !== typeof dir || dir === '') {
     throw new TypeError('writeSync first argument must be a non-empty string')
   }

--- a/test.js
+++ b/test.js
@@ -6,7 +6,6 @@ var fixturify = require('./')
 
 test('writeSync', function (t) {
   rimraf.sync('testdir.tmp')
-  fs.mkdirSync('testdir.tmp')
   fixturify.writeSync('testdir.tmp', {
     'foo.txt': 'foo.txt contents',
     'subdir': {
@@ -113,19 +112,7 @@ test('writeSync remove', function (t) {
   t.end()
 })
 
-test('error conditions', function (t) { test('writeSync requires directory to exist, if given non-empty object', function (t) {
-    t.throws(function () {
-      fixturify.writeSync('doesnotexist', { 'foo.txt': 'contents' })
-    })
-    t.end()
-  })
-
-  test('readSync requires directory to exist', function (t) {
-    t.throws(function () {
-      fixturify.readSync('doesnotexist')
-    })
-    t.end()
-  })
+test('error conditions', function (t) {
 
   test('writeSync arguments requires specific input', function (t) {
     t.throws(function () {
@@ -147,7 +134,6 @@ test('error conditions', function (t) { test('writeSync requires directory to ex
     // Test that we guard against usage errors that might cause data loss
     // through fs.removeSync('' + '/' + '') or similar.
     rimraf.sync('testdir.tmp')
-    fs.mkdirSync('testdir.tmp')
     t.throws(function () {
       fixturify.writeSync('', { })
     }, /non-empty string/)


### PR DESCRIPTION
…teSync`