### PR TITLE
Ensure stat information is reset for each item in fixture when writing

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,9 @@ function writeSync (dir, obj) {
 
       try {
         stat = fs.statSync(fullPath);
-      } catch (e) {}
+      } catch (e) {
+        stat = undefined;
+      }
 
       if (typeof value === 'string') {
         if (stat && stat.isDirectory()) {

--- a/test.js
+++ b/test.js
@@ -155,6 +155,28 @@ test('error conditions', function (t) {
     t.end()
   })
 
+  test('writeSync handles overwriting a file and then creating a new file', function(t) {
+    rimraf.sync('testdir.tmp')
+    fs.mkdirSync('testdir.tmp')
+
+    fixturify.writeSync('testdir.tmp', {
+      'a.txt': 'a.txt content',
+      'b': {}
+    })
+
+    t.deepEqual(fs.readdirSync('testdir.tmp').sort(), ['a.txt', 'b'])
+
+    fixturify.writeSync('testdir.tmp', {
+      'a.txt': 'a.txt updated',
+      'c': {}
+    })
+
+    t.deepEqual(fs.readdirSync('testdir.tmp').sort(), ['a.txt', 'b', 'c'])
+
+    rimraf.sync('testdir.tmp')
+    t.end()
+  })
+
   test('readSync throws on broken symlinks', function(t) {
     rimraf.sync('testdir.tmp')
     fs.mkdirSync('testdir.tmp')


### PR DESCRIPTION
This fixes a tricky bug: if you called `writeSync` and an entry exists (meaning `stat` is defined) and is then followed by an entry that does not exist (meaning `stat` should be undefined), you would get an error. This is because the entry that does not exist is using the `stat` info from the previous entry.

I added a test to ensure this doesn't regress.