### PR TITLE
add ignoreEmptyDirs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,24 @@ fixturify.writeSync('testDir', {
 
 ```
 
+```js
+const fs = require('fs')
+const fixturify = require('fixturify')
+
+const obj = {
+  'subdir': {
+    'foo.txt': 'foo.txt contents'
+  },
+  'emptydir': {}
+}
+
+fixturify.writeSync('testdir', obj) // write it to disk
+
+fixturify.readSync('testdir', { ignoreEmptyDirs: true })
+// => { subdir: { foo.txt': 'foo.txt contents' } }
+
+```
+
 File contents are decoded and encoded with UTF-8.
 
 `fixture.readSync` follows symlinks. It throws an error if it encounters a

--- a/index.ts
+++ b/index.ts
@@ -11,11 +11,13 @@ namespace fixturify {
   export interface Options {
     include?: (IMinimatch | string)[];
     exclude?: (IMinimatch | string)[];
+    ignoreEmptyDirs?: boolean;
   }
 
   export function readSync(dir: string, options: Options = {}, relativeRoot= '') : DirJSON {
     const include = options.include;
     const exclude = options.exclude;
+    const ignoreEmptyDirs = options.ignoreEmptyDirs;
 
     let includeMatcher;
     let excludeMatcher;
@@ -47,6 +49,10 @@ namespace fixturify {
         obj[entry] = fs.readFileSync(fullPath, { encoding: 'utf8' });
       } else if (stats.isDirectory()) {
         obj[entry] = readSync(fullPath, options, relativePath);
+
+        if (ignoreEmptyDirs && !Object.keys(obj[entry] as DirJSON).length) {
+          delete obj[entry];
+        }
       } else {
         throw new Error(`Stat'ed ${fullPath} but it is neither file, symlink, nor directory`);
       }

--- a/test.ts
+++ b/test.ts
@@ -110,6 +110,32 @@ test('readSync exclude', function (t: any) {
   t.end();
 });
 
+test('readSync ignoreEmptyDirs false', function (t: any) {
+  rimraf.sync('testdir.tmp');
+  fs.mkdirSync('testdir.tmp');
+  fs.mkdirSync('testdir.tmp/emptydir');
+
+  t.deepEqual(fixturify.readSync('testdir.tmp'), {
+    'emptydir': {}
+  });
+
+  rimraf.sync('testdir.tmp');
+  t.end();
+});
+
+test('readSync ignoreEmptyDirs true', function (t: any) {
+  rimraf.sync('testdir.tmp');
+  fs.mkdirSync('testdir.tmp');
+  fs.mkdirSync('testdir.tmp/emptydir');
+
+  t.deepEqual(fixturify.readSync('testdir.tmp', {
+    ignoreEmptyDirs: true
+  }), {});
+
+  rimraf.sync('testdir.tmp');
+  t.end();
+});
+
 test('writeSync remove', function (t: any) {
   rimraf.sync('testdir.tmp');
   fs.mkdirSync('testdir.tmp');


### PR DESCRIPTION
Because git ignores empty dirs, you can get into a frustrating scenario where you're comparing equivalent trees where git is concerned, but fixturify's compare will fail.

fixes https://travis-ci.org/ember-cli/ember-cli-update/jobs/510180708#L8493

in use https://github.com/kellyselden/git-fixtures/pull/34