### PR TITLE
Don't publish sourcemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test": "tap --timeout 10 ./test.js"
   },
   "files": [
-    "index.[dj]*"
+    "index.d.ts",
+    "index.js"
   ]
 }


### PR DESCRIPTION
We should publish either the sourcemap + index.ts or neither. Publishing only the sourcemap without the file it refers to creates a poor debugger experience as chrome won't show the js it has, instead only complain about the ts it lacks.
