### PR TITLE
Move dev-only type deps to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,13 @@
   },
   "dependencies": {
     "@types/fs-extra": "^9.0.13",
-    "@types/minimatch": "^3.0.3",
-    "@types/rimraf": "^3.0.2",
     "fs-extra": "^10.1.0",
     "matcher-collection": "^2.0.1",
     "walk-sync": "^3.0.0"
   },
   "devDependencies": {
     "@types/node": "^18.11.7",
+    "@types/rimraf": "^3.0.2",
     "rimraf": "^3.0.2",
     "tap": "^16.3.0",
     "typescript": "^4.8.4"


### PR DESCRIPTION
`@types/rimraf` relates to `rimraf`, which is used here as a dev dependency. It does not need to be installed by users of fixturify.

`@types/minimatch": "^3.0.3"` is redundant as `matcher-collection` provides this already.